### PR TITLE
[REFACTOR] 토큰 관리 관련 리팩토링 진행

### DIFF
--- a/src/main/java/org/sopt/lequuServer/domain/user/dto/response/UserLoginResponseDto.java
+++ b/src/main/java/org/sopt/lequuServer/domain/user/dto/response/UserLoginResponseDto.java
@@ -25,13 +25,11 @@ public class UserLoginResponseDto {
 
     private String socialProfileImage;
 
-    private String socialAccessToken;
-
     public static UserLoginResponseDto of(User loginUser, TokenDto tokenDto) {
 
         return new UserLoginResponseDto(
                 loginUser.getId(), loginUser.getNickname(), tokenDto,
-                loginUser.getSocialPlatform(), loginUser.getSocialNickname(), loginUser.getSocialProfileImage(),
-                loginUser.getSocialAccessToken());
+                loginUser.getSocialPlatform(), loginUser.getSocialNickname(), loginUser.getSocialProfileImage()
+        );
     }
 }

--- a/src/main/java/org/sopt/lequuServer/domain/user/model/User.java
+++ b/src/main/java/org/sopt/lequuServer/domain/user/model/User.java
@@ -39,19 +39,10 @@ public class User extends BaseTimeEntity {
 
     private String socialProfileImage;
 
-    private String socialAccessToken;
-
     // 로그인 새롭게 할 때마다 해당 필드들 업데이트
-    public void updateSocialInfo(String socialNickname, String socialProfileImage, String socialAccessToken) {
+    public void updateSocialInfo(String socialNickname, String socialProfileImage) {
         this.socialNickname = socialNickname;
         this.socialProfileImage = socialProfileImage;
-        this.socialAccessToken = socialAccessToken;
-    }
-
-    private String refreshToken;
-
-    public void updateRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
     }
 
     /**

--- a/src/main/java/org/sopt/lequuServer/global/auth/fegin/kakao/KakaoLoginService.java
+++ b/src/main/java/org/sopt/lequuServer/global/auth/fegin/kakao/KakaoLoginService.java
@@ -53,8 +53,7 @@ public class KakaoLoginService {
         KakaoUserResponse userResponse = kakaoApiClient.getUserInformation("Bearer " + socialAccessToken);
 
         loginUser.updateSocialInfo(userResponse.getKakaoAccount().getProfile().getNickname(),
-                userResponse.getKakaoAccount().getProfile().getProfileImageUrl(),
-                socialAccessToken); //카카오 Access 토큰도 매번 업데이트
+                userResponse.getKakaoAccount().getProfile().getProfileImageUrl());
     }
 
     private static String parseCodeString(String codeString) {

--- a/src/main/java/org/sopt/lequuServer/global/auth/redis/RefreshToken.java
+++ b/src/main/java/org/sopt/lequuServer/global/auth/redis/RefreshToken.java
@@ -18,9 +18,9 @@ import java.util.concurrent.TimeUnit;
 public class RefreshToken {
 
     @Id
-    private String refreshToken;
-
     private Long userId;
+
+    private String refreshToken;
 
     @TimeToLive(unit = TimeUnit.SECONDS)
     private Integer expiration;

--- a/src/main/java/org/sopt/lequuServer/global/auth/redis/TokenRepository.java
+++ b/src/main/java/org/sopt/lequuServer/global/auth/redis/TokenRepository.java
@@ -2,5 +2,5 @@ package org.sopt.lequuServer.global.auth.redis;
 
 import org.springframework.data.repository.CrudRepository;
 
-public interface TokenRepository extends CrudRepository<RefreshToken, String> {
+public interface TokenRepository extends CrudRepository<RefreshToken, Long> {
 }

--- a/src/main/java/org/sopt/lequuServer/global/exception/enums/ErrorType.java
+++ b/src/main/java/org/sopt/lequuServer/global/exception/enums/ErrorType.java
@@ -35,12 +35,12 @@ public enum ErrorType {
     INVALID_SOCIAL_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 소셜 엑세스 토큰입니다."),
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 엑세스 토큰입니다, 엑세스 토큰을 재발급 받아주세요."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다, 다시 로그인을 해주세요."),
-    NOT_MATCH_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "일치하지 않는 리프레시 토큰입니다."),
 
     /**
      * 404 NOT FOUND
      */
     INVALID_USER(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+    NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "존재하지 않는 리프레시 토큰입니다."),
 
     /**
      * 500 INTERNAL SERVER ERROR


### PR DESCRIPTION
## 📌 관련 이슈
closed #22 

## ✨ 어떤 이유로 변경된 내용인지
기존에 User 테이블에 카카오 Access 토큰과, 레큐 서비스 자체의 Refresh 토큰을 저장했었는데, 따로 저장할 필요가 없는 것 같아서 해당 부분을 리팩토링 했습니다.

주요 변경사항
1. 카카오 Access 토큰을 더이상 DB에 저장하지 않음
2. Refresh 토큰을 DB에 저장하지 않는 대신, Refresh 토큰 안에 userId를 저장함
3. Redis에서 userId를 키값으로 관리하기 시작함

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말