### PR TITLE
[FEAT] 홈 API 구현

### DIFF
--- a/src/main/java/org/sopt/lequuServer/InitDb.java
+++ b/src/main/java/org/sopt/lequuServer/InitDb.java
@@ -1,0 +1,76 @@
+package org.sopt.lequuServer;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.sopt.lequuServer.domain.book.model.Book;
+import org.sopt.lequuServer.domain.member.model.Member;
+import org.sopt.lequuServer.domain.member.model.SocialPlatform;
+import org.sopt.lequuServer.domain.note.model.Note;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class InitDb {
+    private final InitService initService;
+
+    @PostConstruct
+    public void init() {
+        initService.dbInit();
+    }
+
+    @Component
+    @Transactional
+    @RequiredArgsConstructor
+    static class InitService {
+
+        private final EntityManager em;
+
+        @Transactional
+        public void dbInit() {
+            Member member = Member.builder()
+                    .socialPlatform(SocialPlatform.KAKAO)
+                    .socialId("dwq4d1sa68xx1qw61")
+                    .build();
+            em.persist(member);
+
+            for (int i = 0; i < 7; i++) {
+                Book book = Book.builder()
+                        .uuid("dwq65d19asx6qw1c")
+                        .favoriteName(String.valueOf(i))
+                        .favoriteImage("dqw84dsaac9q9")
+                        .title(String.valueOf(i))
+                        .description("test")
+                        .backgroundColor(11)
+                        .member(member)
+                        .isPopular(true)
+                        .build();
+                em.persist(book);
+            }
+
+            Book book1 = Book.builder()
+                    .uuid("dwq65d19asx6qw1c")
+                    .favoriteName("test")
+                    .favoriteImage("dqw84dsaac9q9")
+                    .title("test")
+                    .description("test")
+                    .backgroundColor(11)
+                    .member(member)
+                    .isPopular(true)
+                    .build();
+            em.persist(book1);
+
+            for (int i = 0; i < 7; i++) {
+                Note note = Note.builder()
+                        .content(String.valueOf(i))
+                        .background("back")
+                        .textColor(i)
+                        .member(member)
+                        .book(book1)
+                        .build();
+                em.persist(note);
+            }
+        }
+    }
+}

--- a/src/main/java/org/sopt/lequuServer/domain/book/controller/BookController.java
+++ b/src/main/java/org/sopt/lequuServer/domain/book/controller/BookController.java
@@ -3,7 +3,7 @@ package org.sopt.lequuServer.domain.book.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sopt.lequuServer.domain.book.dto.request.BookCreateRequest;
-import org.sopt.lequuServer.domain.book.dto.response.BookCreateResponse;
+import org.sopt.lequuServer.domain.book.dto.response.BookCreateResponseDto;
 import org.sopt.lequuServer.domain.book.facade.BookFacade;
 import org.sopt.lequuServer.global.auth.jwt.JwtProvider;
 import org.sopt.lequuServer.global.common.dto.ApiResponse;
@@ -23,7 +23,7 @@ public class BookController {
     private final BookFacade bookFacade;
 
     @PostMapping
-    public ApiResponse<BookCreateResponse> createBook(@Valid @RequestBody BookCreateRequest request, Principal principal) {
+    public ApiResponse<BookCreateResponseDto> createBook(@Valid @RequestBody BookCreateRequest request, Principal principal) {
         return ApiResponse.success(SuccessType.BOOK_CREATE_SUCCESS, bookFacade.createBook(request, JwtProvider.getUserFromPrincial(principal)));
     }
 }

--- a/src/main/java/org/sopt/lequuServer/domain/book/dto/response/BookCreateResponseDto.java
+++ b/src/main/java/org/sopt/lequuServer/domain/book/dto/response/BookCreateResponseDto.java
@@ -2,12 +2,12 @@ package org.sopt.lequuServer.domain.book.dto.response;
 
 import org.sopt.lequuServer.domain.book.model.Book;
 
-public record BookCreateResponse(
+public record BookCreateResponseDto(
         Long bookId,
         String bookUuid
 ) {
-    public static BookCreateResponse of(Book book) {
-        return new BookCreateResponse(
+    public static BookCreateResponseDto of(Book book) {
+        return new BookCreateResponseDto(
                 book.getId(),
                 book.getUuid()
         );

--- a/src/main/java/org/sopt/lequuServer/domain/book/facade/BookFacade.java
+++ b/src/main/java/org/sopt/lequuServer/domain/book/facade/BookFacade.java
@@ -1,8 +1,11 @@
 package org.sopt.lequuServer.domain.book.facade;
 
+import static org.sopt.lequuServer.global.s3.enums.ImageFolderName.BOOK_FAVORITE_IMAGE_FOLDER_NAME;
+
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.sopt.lequuServer.domain.book.dto.request.BookCreateRequest;
-import org.sopt.lequuServer.domain.book.dto.response.BookCreateResponse;
+import org.sopt.lequuServer.domain.book.dto.response.BookCreateResponseDto;
 import org.sopt.lequuServer.domain.book.model.Book;
 import org.sopt.lequuServer.domain.book.service.BookService;
 import org.sopt.lequuServer.domain.member.model.Member;
@@ -10,10 +13,6 @@ import org.sopt.lequuServer.domain.member.service.MemberService;
 import org.sopt.lequuServer.global.s3.service.S3Service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.UUID;
-
-import static org.sopt.lequuServer.global.s3.enums.ImageFolderName.BOOK_FAVORITE_IMAGE_FOLDER_NAME;
 
 @Service
 @RequiredArgsConstructor
@@ -25,7 +24,7 @@ public class BookFacade {
     private final S3Service s3Service;
 
     @Transactional
-    public BookCreateResponse createBook(BookCreateRequest request, Long memberId) {
+    public BookCreateResponseDto createBook(BookCreateRequest request, Long memberId) {
 
         // 유저 검증이 완료된 후에 새로운 Book 객체를 생성할 수 있는 것
         Member member = memberService.getMember(memberId);

--- a/src/main/java/org/sopt/lequuServer/domain/book/model/Book.java
+++ b/src/main/java/org/sopt/lequuServer/domain/book/model/Book.java
@@ -38,6 +38,8 @@ public class Book extends BaseTimeEntity {
 
     private int backgroundColor;
 
+    private boolean isPopular;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
@@ -65,6 +67,7 @@ public class Book extends BaseTimeEntity {
         this.description = description;
         this.backgroundColor = backgroundColor;
         this.member = member;
+        this.isPopular = false;
     }
 
     public static Book of(String uuid, String favoriteName, String favoriteImage, String title, String description, int backgroundColor, Member member) {

--- a/src/main/java/org/sopt/lequuServer/domain/book/model/Book.java
+++ b/src/main/java/org/sopt/lequuServer/domain/book/model/Book.java
@@ -59,7 +59,7 @@ public class Book extends BaseTimeEntity {
     }
 
     @Builder
-    public Book(String uuid, String favoriteName, String favoriteImage, String title, String description, int backgroundColor, Member member) {
+    public Book(String uuid, String favoriteName, String favoriteImage, String title, String description, int backgroundColor, Member member, boolean isPopular) {
         this.uuid = uuid;
         this.favoriteName = favoriteName;
         this.favoriteImage = favoriteImage;
@@ -67,11 +67,11 @@ public class Book extends BaseTimeEntity {
         this.description = description;
         this.backgroundColor = backgroundColor;
         this.member = member;
-        this.isPopular = false;
+        this.isPopular = isPopular;
     }
 
-    public static Book of(String uuid, String favoriteName, String favoriteImage, String title, String description, int backgroundColor, Member member) {
-        return new Book(uuid, favoriteName, favoriteImage, title, description, backgroundColor, member);
+    public static Book of(String uuid, String favoriteName, String favoriteImage, String title, String description, int backgroundColor, Member member, boolean isPopular) {
+        return new Book(uuid, favoriteName, favoriteImage, title, description, backgroundColor, member, isPopular);
     }
 
     // TODO S3 테스트용, 추후 삭제

--- a/src/main/java/org/sopt/lequuServer/domain/book/repository/BookRepository.java
+++ b/src/main/java/org/sopt/lequuServer/domain/book/repository/BookRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
-    @Query(value = "select b from Book  b where b.isPopular = :isPopular")
+    @Query(value = "select b from Book b where b.isPopular = :isPopular")
     List<Book> getAllByPopular(@Param("isPopular") Boolean isPopular, PageRequest pageRequest);
 }

--- a/src/main/java/org/sopt/lequuServer/domain/book/repository/BookRepository.java
+++ b/src/main/java/org/sopt/lequuServer/domain/book/repository/BookRepository.java
@@ -1,7 +1,13 @@
 package org.sopt.lequuServer.domain.book.repository;
 
+import java.util.List;
 import org.sopt.lequuServer.domain.book.model.Book;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
+    @Query(value = "select b from Book  b where b.isPopular = :isPopular")
+    List<Book> getAllByPopular(@Param("isPopular") Boolean isPopular, PageRequest pageRequest);
 }

--- a/src/main/java/org/sopt/lequuServer/domain/book/service/BookService.java
+++ b/src/main/java/org/sopt/lequuServer/domain/book/service/BookService.java
@@ -1,0 +1,19 @@
+package org.sopt.lequuServer.domain.book.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.lequuServer.domain.book.model.Book;
+import org.sopt.lequuServer.domain.book.repository.BookRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BookService {
+
+    private final BookRepository bookRepository;
+
+    public List<Book> getPopularBook() {
+        return bookRepository.getAllByPopular(true, PageRequest.of(0, 6));
+    }
+}

--- a/src/main/java/org/sopt/lequuServer/domain/book/service/BookService.java
+++ b/src/main/java/org/sopt/lequuServer/domain/book/service/BookService.java
@@ -1,9 +1,7 @@
 package org.sopt.lequuServer.domain.book.service;
 
-import java.util.List;
-import org.springframework.data.domain.PageRequest;
 import lombok.RequiredArgsConstructor;
-import org.sopt.lequuServer.domain.book.dto.response.BookCreateResponse;
+import org.sopt.lequuServer.domain.book.dto.response.BookCreateResponseDto;
 import org.sopt.lequuServer.domain.book.model.Book;
 import org.sopt.lequuServer.domain.book.repository.BookRepository;
 import org.springframework.stereotype.Service;
@@ -16,13 +14,8 @@ public class BookService {
 
     private final BookRepository bookRepository;
 
-    public List<Book> getPopularBook() {
-        return bookRepository.getAllByPopular(true, PageRequest.of(0, 6));
-    }
-}
-
     @Transactional
-    public BookCreateResponse createBook(Book book) {
-        return BookCreateResponse.of(bookRepository.save(book));
+    public BookCreateResponseDto createBook(Book book) {
+        return BookCreateResponseDto.of(bookRepository.save(book));
     }
 }

--- a/src/main/java/org/sopt/lequuServer/domain/common/controller/CommonController.java
+++ b/src/main/java/org/sopt/lequuServer/domain/common/controller/CommonController.java
@@ -1,15 +1,19 @@
 package org.sopt.lequuServer.domain.common.controller;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt.lequuServer.domain.common.dto.response.PopularBookResponseDto;
 import org.sopt.lequuServer.domain.common.dto.response.SplashDto;
 import org.sopt.lequuServer.domain.common.facade.CommonFacade;
 import org.sopt.lequuServer.global.common.dto.ApiResponse;
 import org.sopt.lequuServer.global.exception.enums.SuccessType;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RestController("/api/common")
+@RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/common")
 public class CommonController {
 
     private final CommonFacade commonFacade;
@@ -19,4 +23,9 @@ public class CommonController {
         return ApiResponse.success(SuccessType.GET_SPLASH_SUCCESS, commonFacade.getSplash());
     }
 
+    @GetMapping("/home")
+    public ApiResponse<List<PopularBookResponseDto>> getHome() {
+        return ApiResponse.success(SuccessType.GET_HOME_SUCCESS, commonFacade.getHome());
+    }
 }
+

--- a/src/main/java/org/sopt/lequuServer/domain/common/dto/response/PopularBookResponseDto.java
+++ b/src/main/java/org/sopt/lequuServer/domain/common/dto/response/PopularBookResponseDto.java
@@ -1,0 +1,15 @@
+package org.sopt.lequuServer.domain.common.dto.response;
+
+import org.sopt.lequuServer.domain.book.model.Book;
+
+public record PopularBookResponseDto(
+        Long bookId,
+        String bookUuid,
+        String favoriteName,
+        String favoriteImage
+) {
+    public static PopularBookResponseDto of(Book book) {
+        return new PopularBookResponseDto(book.getId(), book.getUuid(), book.getFavoriteName(),
+                book.getFavoriteImage());
+    }
+}

--- a/src/main/java/org/sopt/lequuServer/domain/common/facade/CommonFacade.java
+++ b/src/main/java/org/sopt/lequuServer/domain/common/facade/CommonFacade.java
@@ -1,6 +1,9 @@
 package org.sopt.lequuServer.domain.common.facade;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt.lequuServer.domain.book.service.BookService;
+import org.sopt.lequuServer.domain.common.dto.response.PopularBookResponseDto;
 import org.sopt.lequuServer.domain.common.dto.response.SplashDto;
 import org.sopt.lequuServer.domain.note.service.NoteService;
 import org.springframework.stereotype.Service;
@@ -10,9 +13,14 @@ import org.springframework.stereotype.Service;
 public class CommonFacade {
 
     private final NoteService noteService;
+    private final BookService bookService;
 
     public SplashDto getSplash() {
         return SplashDto.of(noteService.getAllNoteCount());
+    }
+
+    public List<PopularBookResponseDto> getHome() {
+        return bookService.getPopularBook().stream().map(PopularBookResponseDto::of).toList();
     }
 
 }

--- a/src/main/java/org/sopt/lequuServer/domain/common/facade/CommonFacade.java
+++ b/src/main/java/org/sopt/lequuServer/domain/common/facade/CommonFacade.java
@@ -2,10 +2,11 @@ package org.sopt.lequuServer.domain.common.facade;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.sopt.lequuServer.domain.book.service.BookService;
+import org.sopt.lequuServer.domain.book.repository.BookRepository;
 import org.sopt.lequuServer.domain.common.dto.response.PopularBookResponseDto;
 import org.sopt.lequuServer.domain.common.dto.response.SplashDto;
 import org.sopt.lequuServer.domain.note.service.NoteService;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -13,14 +14,16 @@ import org.springframework.stereotype.Service;
 public class CommonFacade {
 
     private final NoteService noteService;
-    private final BookService bookService;
+    private final BookRepository bookRepository;
 
     public SplashDto getSplash() {
         return SplashDto.of(noteService.getAllNoteCount());
     }
 
     public List<PopularBookResponseDto> getHome() {
-        return bookService.getPopularBook().stream().map(PopularBookResponseDto::of).toList();
+        return bookRepository.getAllByPopular(true, PageRequest.of(0, 6))
+                .stream().map(PopularBookResponseDto::of)
+                .toList();
     }
 
 }

--- a/src/main/java/org/sopt/lequuServer/domain/note/model/Note.java
+++ b/src/main/java/org/sopt/lequuServer/domain/note/model/Note.java
@@ -10,7 +10,8 @@ import org.sopt.lequuServer.global.common.model.BaseTimeEntity;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "note")
-public class Note extends BaseTimeEntity {
+public class
+Note extends BaseTimeEntity {
 
     @Id
     @Column(name = "note_id")

--- a/src/main/java/org/sopt/lequuServer/domain/note/model/Note.java
+++ b/src/main/java/org/sopt/lequuServer/domain/note/model/Note.java
@@ -10,8 +10,7 @@ import org.sopt.lequuServer.global.common.model.BaseTimeEntity;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "note")
-public class
-Note extends BaseTimeEntity {
+public class Note extends BaseTimeEntity {
 
     @Id
     @Column(name = "note_id")

--- a/src/main/java/org/sopt/lequuServer/global/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/lequuServer/global/config/SecurityConfig.java
@@ -23,7 +23,8 @@ public class SecurityConfig {
     private static final String[] AUTH_WHITELIST = {
             "/api/kakao/**", "/loading", "/error", "/api/login", "/api/reissue",
             "/api/test/**", "/health", "/actuator/health",
-            "/api/images/**", "/", "/swagger-ui/**", "/swagger-resources/**", "/api-docs/**"
+            "/api/images/**", "/", "/swagger-ui/**", "/swagger-resources/**", "/api-docs/**",
+            "/api/common/**"
     };
 
     @Bean

--- a/src/main/java/org/sopt/lequuServer/global/exception/enums/SuccessType.java
+++ b/src/main/java/org/sopt/lequuServer/global/exception/enums/SuccessType.java
@@ -22,6 +22,7 @@ public enum SuccessType {
 
     STICKER_PACK_LIST_SUCCESS(HttpStatus.OK, "스티커팩 목록 조회에 성공했습니다."),
     GET_SPLASH_SUCCESS(HttpStatus.OK, "스플래시 조회에 성공했습니다."),
+    GET_HOME_SUCCESS(HttpStatus.OK, "홈 화면 조회에 성공했습니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] 기능 추가
- [FIX] 에러 수정, 버그 수정
- [CHORE] gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] README, 문서
- [REFACTOR] 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #8 
## ✨ 어떤 이유로 변경된 내용인지
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->
* 홈 조회 api를 구현했습니다.
* 인기있는 레큐북 6개가 조회됩니다.
* 테스트를 위한 InitDb Component를 구현했습니다.

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
<!-- Reviewers, Assignees, Labels 지정해주세요 -->
* 인기있는 레큐북은 기획단에서 SQL로 수정을 할 수 있기를 원하기에 boolean 필드로 추가했습니다.
* JPA에 limit 쿼리가 지원 안되기에 native 쿼리로 작성했습니다.
* InitDb 데이터는 DB가 실행될 때 초기 데이터로 입력됩니다.